### PR TITLE
test(router): add parseHash unit tests

### DIFF
--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import Home from "./pages/Home";
 import ProjectPage from "./components/ProjectPage";
 
-function parseHash() {
+export function parseHash() {
   const h = window.location.hash || "";
   const m = h.match(/^#\/(?:projects\/([\w-]+))?$/);
   if (m && m[1]) return { route: "project", slug: m[1] };

--- a/src/Router.test.jsx
+++ b/src/Router.test.jsx
@@ -1,0 +1,22 @@
+import { parseHash } from './Router';
+
+describe('parseHash', () => {
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  test.each(['', '#/'])("returns home for '%s'", (hash) => {
+    window.location.hash = hash;
+    expect(parseHash()).toEqual({ route: 'home' });
+  });
+
+  test("parses project slug 'thesis'", () => {
+    window.location.hash = '#/projects/thesis';
+    expect(parseHash()).toEqual({ route: 'project', slug: 'thesis' });
+  });
+
+  test("parses project slug 'unknown'", () => {
+    window.location.hash = '#/projects/unknown';
+    expect(parseHash()).toEqual({ route: 'project', slug: 'unknown' });
+  });
+});


### PR DESCRIPTION
## Summary
- export `parseHash` helper
- add tests for parseHash routing logic

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689d2b2b2b008324a57f1dbdec13d941