### PR TITLE
Align core section scroll to top on mobile

### DIFF
--- a/src/components/ScrollButton.jsx
+++ b/src/components/ScrollButton.jsx
@@ -9,7 +9,8 @@ export default function ScrollButton({ targetId, align = "start", offset = 0, cl
     const el = document.getElementById(targetId);
     if (!el) return;
     const y = el.getBoundingClientRect().top + window.scrollY;
-    const base = align === "center"
+    const isMobile = window.matchMedia("(max-width: 768px)").matches;
+    const base = align === "center" && !isMobile
       ? y - (window.innerHeight / 2 - el.offsetHeight / 2)
       : y;
     window.scrollTo({ top: base + offset, behavior: "smooth" });


### PR DESCRIPTION
## Summary
- prevent core scroll button from centering section on small screens
- default to scrolling to start of section title for mobile devices

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689d32eb23a48324b8c9ddbedc0b2552