### PR TITLE
Add lightbox and lazy loading for project images

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -176,3 +176,28 @@ u {
 .cap-card .cap-desc { opacity: .85; }
 .cap-card .cap-tags { display: flex; flex-wrap: wrap; gap: 8px; }
 .cap-card .cap-link { margin-top: 12px; }
+/* Lightbox styles */
+.lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.lightbox-img {
+  max-width: 90%;
+  max-height: 90%;
+}
+.lightbox-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+}

--- a/src/components/CapabilityCard.jsx
+++ b/src/components/CapabilityCard.jsx
@@ -19,7 +19,7 @@ export default function CapabilityCard({ project = null }) {
 
       {/* 과거 방식(이미지 경로 직접)도 지원 */}
       {!imageClass && image && (
-        <img className="cap-img" src={image} alt={title} />
+        <img className="cap-img" src={image} alt={title} loading="lazy" />
       )}
 
       <h3 className="capability-title">{title}</h3>

--- a/src/components/LightboxImage.jsx
+++ b/src/components/LightboxImage.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+export default function LightboxImage({ src, thumb, alt = '', className = '', style = {}, ...props }) {
+  const [open, setOpen] = useState(false);
+  const displaySrc = thumb || src;
+  return (
+    <>
+      <img
+        src={displaySrc}
+        alt={alt}
+        className={className}
+        style={{ cursor: 'zoom-in', maxWidth: '100%', ...style }}
+        loading="lazy"
+        onClick={() => setOpen(true)}
+        {...props}
+      />
+      {open && (
+        <div className="lightbox" onClick={() => setOpen(false)}>
+          <button
+            type="button"
+            className="lightbox-close"
+            aria-label="Close"
+            onClick={() => setOpen(false)}
+          >×</button>
+          <img src={src} alt={alt} className="lightbox-img" />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -22,7 +22,14 @@ export default function ProjectCard({ project = null }) {
 
   return (
     <article className="card card-col-4">
-      {imgSrc && <img src={imgSrc} alt={title} style={{width:'100%',borderRadius:'12px',marginBottom:'12px'}} />}
+      {imgSrc && (
+        <img
+          src={imgSrc}
+          alt={title}
+          style={{width:'100%',borderRadius:'12px',marginBottom:'12px'}}
+          loading="lazy"
+        />
+      )}
       <h3 style={{ fontSize: 18, margin: '8px 0' }}>{title}</h3>
       {description && <p style={{ opacity:.85 }}>{description}</p>}
       {Array.isArray(tech) && tech.length > 0 && (

--- a/src/components/ProjectsList.jsx
+++ b/src/components/ProjectsList.jsx
@@ -29,7 +29,7 @@ export default function ProjectsList() {
         {projects.map((p) => (
           <article className="project-row" key={p.slug}>
             <a href={`#/projects/${p.slug}`} onClick={(e) => go(p.slug, e)} className="project-thumb">
-              <img src={p.hero} alt={p.title} />
+              <img src={p.thumb || p.hero} alt={p.title} loading="lazy" />
             </a>
             <div className="project-body">
               <h3 className="project-title">

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -5,12 +5,14 @@ const projects = [
     title: "Pimatgol, Walkable Again: Craft-Industry Regeneration in Jongno",
     excerpt: "Urban-regeneration strategy for Jongno’s historic Pimatgol that restores a human-scale, walkable alley and populates it with “Makers” from the nearby Sewoon/Euljiro ecosystem—supported by a modular, parametric façade system that delivers shading and identity. ",
     hero: "/images/projects/thesis/hero.png",
+    thumb: "/images/projects/thesis/hero.png",
   },
-    {
+  {
     slug: "jungle",
     title: "Raising the Alley: A Vertical Public Realm over Donui-dong",
     excerpt: "Urban-regeneration proposal for Donui-dong’s jjokbangchon that preserves the ground-level alley texture as exhibition/retail, caps it with a structural pedestrian deck as shared open space, and adds compliant one-person housing above—supplemented by lifestyle lodging to make participation economically viable.",
     hero: "/images/projects/jungle/hero.png",
+    thumb: "/images/projects/jungle/hero.png",
   }
 ];
 

--- a/src/projects/Jungle.jsx
+++ b/src/projects/Jungle.jsx
@@ -1,10 +1,11 @@
 // src/projects/Jungle.jsx
 import React from "react";
 import Template from "./Template";
+import LightboxImage from "../components/LightboxImage";
 
 export default function Jungle() {
   return (
-    <Template title="Raising the Alley: A Vertical Public Realm over Donui-dong" hero="/images/projects/jungle/hero.png">
+    <Template title="Raising the Alley: A Vertical Public Realm over Donui-dong" hero="/images/projects/jungle/hero.png" heroSmall="/images/projects/jungle/hero.png">
       <p>
       Donui-dong in central Seoul is home to one of the city's last remaining jjokbangchon — an informal settlement of tiny one-room dwellings. 
       Here, about 576 residents live in cramped units as small as 1.25 pyeong (4 square meters) across a maze of 88 aging buildings. 
@@ -12,28 +13,28 @@ export default function Jungle() {
       The living conditions are severe, with many inhabitants being elderly or formerly homeless individuals barely scraping by. 
       Yet the neighborhood's labyrinthine character and tightly-knit social fabric carry a certain intrigue and sense of community. 
       </p>
-      <img src="/images/projects/jungle/jungle_1.png" alt="Raising the Alley project image 1"/>
+      <LightboxImage src="/images/projects/jungle/jungle_1.png" alt="Raising the Alley project image 1" style={{margin:'16px 0'}} />
       <p>
       This studio project confronts the social challenges of Donui-dong's jjokbangchon with a bold, layered design approach. 
       Visiting the site, the designers observed that from within the alleys, the sky was barely visible above the tightly-packed shacks. 
       This observation inspired the concept of 'raising the alley' — literally elevating the communal ground to give residents space, light, and a new vantage point. 
       The design seeks to create an opportunity for upward movement (both physical and social) for the jjokbangchon's residents, without erasing the area's identity. 
       </p>
-      <img src="/images/projects/jungle/jungle_2.png" alt="Raising the Alley project image 2"/>
+      <LightboxImage src="/images/projects/jungle/jungle_2.png" alt="Raising the Alley project image 2" style={{margin:'16px 0'}} />
       <p>
       Instead of wholesale demolition, the proposal preserves portions of the existing alley fabric at ground level, maintaining the authentic maze-like atmosphere. 
       These retained structures and narrow passages are repurposed into a sort of living museum — housing small exhibits, workshops, and retail that showcase the history and stories of the jjokbangchon. 
       The familiar gritty alleyway environment thus remains accessible, now inviting visitors to explore and learn, while providing former residents an anchor to their past. 
       By keeping the ground plane alive and recognizable, the design ensures the spirit of Donui-dong is not lost in redevelopment. 
       </p>
-      <img src="/images/projects/jungle/jungle_3.png" alt="Raising the Alley project image 3"/>
+      <LightboxImage src="/images/projects/jungle/jungle_3.png" alt="Raising the Alley project image 3" style={{margin:'16px 0'}} />
       <p>
       Above this preserved ground, a new elevated pedestrian network is introduced — essentially raising the alley into the air. 
       A bold structural platform weaves over the site, creating an open public realm one level up. 
       This elevated promenade becomes the new heart of the community: an outdoor hallway and terrace where residents can stroll, gather, and enjoy sunlight and fresh air, all within their own neighborhood. 
       By covering the old alleys with this structural walk, the design also adds a dramatic spatial layer that sparks curiosity and draws outsiders to venture in. 
       </p>
-      <img src="/images/projects/jungle/jungle_4.png" alt="Raising the Alley project image 4"/>
+      <LightboxImage src="/images/projects/jungle/jungle_4.png" alt="Raising the Alley project image 4" style={{margin:'16px 0'}} />
       <p>
       On top of the pedestrian deck, the project then introduces new housing and other programs. 
       Clusters of code-compliant micro-unit apartments are built above, providing safe and decent homes for the jjokbangchon's residents. 
@@ -41,14 +42,14 @@ export default function Jungle() {
       In addition, one portion of the site is dedicated to a lifestyle lodging tower — essentially a small hotel or serviced residence — that generates revenue. 
       This mix of programs establishes a sustainable financial model: the lodging draws visitors and income that help support the subsidized housing and persuade landowners to invest in the renewal. 
       </p>
-      <img src="/images/projects/jungle/jungle_5.png" alt="Raising the Alley project image 5"/>
+      <LightboxImage src="/images/projects/jungle/jungle_5.png" alt="Raising the Alley project image 5" style={{margin:'16px 0'}} />
       <p>
       The result is a layered village that uplifts its residents while inviting the city in. 
       By strategically combining social housing with commercial uses, the scheme achieves both community benefit and economic viability. 
       Most importantly, it retains the soul of Donui-dong — the intimate alleyways and their stories — rather than replacing them with anonymous towers. 
       'Raising the Alley' demonstrates a compassionate approach to urban regeneration: one that builds upward toward hope while keeping the roots of the place firmly intact. 
       </p>
-      <img src="/images/projects/jungle/jungle_6.png" alt="Raising the Alley project image 6"/>
+      <LightboxImage src="/images/projects/jungle/jungle_6.png" alt="Raising the Alley project image 6" style={{margin:'16px 0'}} />
     </Template>
   );
 }

--- a/src/projects/Template.jsx
+++ b/src/projects/Template.jsx
@@ -1,12 +1,13 @@
 // src/projects/Template.jsx
 import React from "react";
+import LightboxImage from "../components/LightboxImage";
 
-export default function Template({ title, hero, children }) {
+export default function Template({ title, hero, heroSmall, children }) {
   return (
     <article className="container section project-detail">
       {hero && (
         <div className="project-hero">
-          <img src={hero} alt={title} />
+          <LightboxImage src={hero} thumb={heroSmall} alt={title} style={{margin:'0 0 24px'}} />
         </div>
       )}
       <h1><span className="badge">{title}</span></h1>

--- a/src/projects/Thesis.jsx
+++ b/src/projects/Thesis.jsx
@@ -1,29 +1,30 @@
 // src/projects/Thesis.jsx
 import React from "react";
 import Template from "./Template";
+import LightboxImage from "../components/LightboxImage";
 
 export default function Thesis() {
   return (
-    <Template title="Pimatgol, Walkable Again: Craft-Industry Regeneration in Jongno" hero="/images/projects/thesis/hero.png">
+    <Template title="Pimatgol, Walkable Again: Craft-Industry Regeneration in Jongno" hero="/images/projects/thesis/hero.png" heroSmall="/images/projects/thesis/hero.png">
       <p>
       Tucked parallel to Seoul's bustling Jongno Avenue, Pimatgol alley has long been a hidden pedestrian passage with deep roots in the city's history. 
       Originally created centuries ago to let commoners dodge noblemen on horseback along Jongno, this narrow lane grew into a lively corridor of shops, eateries, and everyday life. 
       In recent decades, however, rapid redevelopment and neglect have left Pimatgol faded and largely forgotten—its once-vibrant alley culture at risk of disappearing. 
       </p>
-      <img src="/images/projects/thesis/thesis_1.png" alt="Pimatgol project image 1"/>
+      <LightboxImage src="/images/projects/thesis/thesis_1.png" alt="Pimatgol project image 1" style={{margin:'16px 0'}} />
       <p>
       This graduation project reimagines Pimatgol as a pedestrian-first urban corridor that revives its spirit for the modern era. 
       Rather than succumbing to large-scale redevelopment that wipes away the alley's character, the proposal takes a sensitive approach that preserves Pimatgol's human scale and social memory. 
       The design introduces a network of small workshops, studios, and retail spaces run by local "makers," breathing new life into the alley while celebrating the neighborhood's craft heritage. 
       </p>
-      <img src="/images/projects/thesis/thesis_2.png" alt="Pimatgol project image 2"/>
+      <LightboxImage src="/images/projects/thesis/thesis_2.png" alt="Pimatgol project image 2" style={{margin:'16px 0'}} />
       <p>
       Key to the concept is the integration of the "Maker" culture from the adjoining Sewoon and Euljiro districts—Seoul's historic manufacturing hub. 
       Pimatgol's new workshops are operated by craftspeople, artists, and small manufacturers who utilize the neighborhood's existing industrial infrastructure. 
       By turning the alley into an open-air extension of this maker community, the design not only revitalizes the street economy but also forges a symbiosis with the surrounding urban fabric. 
       The once-forgotten backstreet is envisioned as a vibrant lane where pedestrians can observe, shop, and engage with craft and industry firsthand. 
       </p>
-      <img src="/images/projects/thesis/thesis_3.png" alt="Pimatgol project image 3"/>
+      <LightboxImage src="/images/projects/thesis/thesis_3.png" alt="Pimatgol project image 3" style={{margin:'16px 0'}} />
       <p>
       In terms of urban design, the scheme transforms the physical layout of Pimatgol while respecting its intimate scale. 
       The alley is pedestrianized and enhanced with better paving, lighting, and pocket plazas that invite people to linger. 
@@ -31,7 +32,7 @@ export default function Thesis() {
       Ground floors are kept open and active—hosting maker workshops and tiny retail units that open directly onto the lane—ensuring continuous street life. 
       Upper levels accommodate studios or living spaces for the makers, fostering a live-work community that animates the alley day and night. 
       </p>
-      <img src="/images/projects/thesis/thesis_4.png" alt="Pimatgol project image 4"/>
+      <LightboxImage src="/images/projects/thesis/thesis_4.png" alt="Pimatgol project image 4" style={{margin:'16px 0'}} />
       <p>
       Architecturally, the project blends contemporary design with subtle references to craft. 
       A unifying feature is the facade treatment: a modern curtain wall system wrapped by vertical twisted aluminum panels that act as both solar screens and decorative elements. 
@@ -39,14 +40,14 @@ export default function Thesis() {
       This dynamic facade not only provides environmental control but also nods to the local metalworking and manufacturing heritage. 
       The modular system was developed using computational design tools, allowing complex patterns to be optimized and fabricated with precision. 
       </p>
-      <img src="/images/projects/thesis/thesis_5.png" alt="Pimatgol project image 5"/>
+      <LightboxImage src="/images/projects/thesis/thesis_5.png" alt="Pimatgol project image 5" style={{margin:'16px 0'}} />
       <p>
       Ultimately, the project strives to make Pimatgol "walkable again" in every sense. 
       By revitalizing the alley's social and economic life and weaving new architecture into the historic fabric, it creates a vibrant public realm where old and new coexist. 
       Pimatgol becomes a lively pedestrian passage once more—a catalyst for street life that serves as a model for alleyway regeneration in Seoul. 
       This design proves that honoring local heritage and embracing innovation can go hand in hand, breathing new life into a treasured urban space. 
       </p>
-      <img src="/images/projects/thesis/thesis_6.png" alt="Pimatgol project image 6"/>
+      <LightboxImage src="/images/projects/thesis/thesis_6.png" alt="Pimatgol project image 6" style={{margin:'16px 0'}} />
     </Template>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `LightboxImage` component to open images in a modal overlay
- replace project images with lightbox-enabled versions and add lazy loading to cards
- extend project data for future thumbnails and include lightbox styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d733016f083248ea7867eb0802eab